### PR TITLE
Updated RegEx to not match custom data-attributes

### DIFF
--- a/Classes/Hooks/ContentPostProcessor.php
+++ b/Classes/Hooks/ContentPostProcessor.php
@@ -43,8 +43,8 @@ class ContentPostProcessor {
     }
 	
 	function readFilesFromContent() {
-		preg_match_all('/href="([^"]+\.css[^"]*)"|src="([^"]+\.js[^"]*)"|src="([^"]+\.jpg[^"]*)"|src="([^"]+\.png[^"]*)"/', $GLOBALS['TSFE']->content, $matches);
-		$result = array_filter(array_merge($matches[1], $matches[2], $matches[3], $matches[4]));
+		preg_match_all('/href="([^"]+\.css[^"]*)"|(?<![\w-])src="([^"]+\.(?:jpg|png|js|gif|svg)[^"]*)"/', $GLOBALS['TSFE']->content, $matches);
+		$result = array_filter(array_merge($matches[1], $matches[2]));
 		foreach($result as $file) {
 			if($this->checkFileForInternal($file)) {
 				if (substr($file, 0, 1) === '/') {


### PR DESCRIPTION
 Updated regex to not match custom data-attributes in the MarkUp that end in "src=" like "data-imagesrc=". Added gif and svg as valid source-targets. The regex is even a little bit faster due to less matching groups.